### PR TITLE
Setup BST 282 sub-app

### DIFF
--- a/build/rstudio-bioconductor.def
+++ b/build/rstudio-bioconductor.def
@@ -1,0 +1,2 @@
+Bootstrap: docker
+From: bioconductor/bioconductor_docker:RELEASE_3_20

--- a/form.yml
+++ b/form.yml
@@ -2,6 +2,7 @@
 cluster: "*"
 
 attributes:
+  imagefile: rstudio-base.sif
   custom_num_cores:
     widget: "number_field"
     label: "Number of CPUs"
@@ -12,3 +13,4 @@ attributes:
 form:
   - custom_num_cores
   - bc_num_hours
+  - imagefile

--- a/local/bst282.yml.erb
+++ b/local/bst282.yml.erb
@@ -33,9 +33,8 @@ cluster: "<%= cluster %>"
 
 title: "RStudio - BST 282"
 
-imagefile: rstudio-bioconductor.sif
-
 attributes:
+  imagefile: rstudio-bioconductor.sif
   custom_num_cores:
     widget: "number_field"
     label: "Number of CPUs"

--- a/local/bst282.yml.erb
+++ b/local/bst282.yml.erb
@@ -33,6 +33,8 @@ cluster: "<%= cluster %>"
 
 title: "RStudio - BST 282"
 
+imagefile: rstudio-bioconductor.sif
+
 attributes:
   custom_num_cores:
     widget: "number_field"
@@ -44,3 +46,4 @@ attributes:
 form:
   - custom_num_cores
   - bc_num_hours
+  - imagefile

--- a/local/bst282.yml.erb
+++ b/local/bst282.yml.erb
@@ -3,25 +3,37 @@
 # @note Used to define the submitted cluster, title, description, and
 #   hard-coded/user-defined attributes that make up this Batch Connect app.
 <%-
-userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
-enabledGroups = [
-  "135510", # HUIT Open OnDemand Testing
-  "150890"  # BST 282: Introduction to Computational Biology and Bioinformatics
-]
-
 def arrays_have_common_element(array1, array2)
   # Use the `&` operator to get the intersection of the two arrays
   # If the intersection is not empty, return true, otherwise false
   !(array1 & array2).empty?
 end
 
-# Check if the groups that the user is in match any of the courses that should
-# have access to this app.
-
-if arrays_have_common_element(userGroups, enabledGroups)
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+if arrays_have_common_element(userGroups, adminGroups)
   cluster="*"
 else
-  cluster="disable_this_app"
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+  enabledGroups = [
+    # Cannot have other enabled groups if a course installation is in use
+    # This is because the course installation uses the course shared folder,
+    # which is not accessible to users outside of that course.
+    "150890"  # BST 282: Introduction to Computational Biology and Bioinformatics
+  ]
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
 end
 -%>
 ---

--- a/local/bst282.yml.erb
+++ b/local/bst282.yml.erb
@@ -1,0 +1,46 @@
+# Batch Connect app configuration file
+#
+# @note Used to define the submitted cluster, title, description, and
+#   hard-coded/user-defined attributes that make up this Batch Connect app.
+<%-
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name).flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+enabledGroups = [
+  "135510", # HUIT Open OnDemand Testing
+  "150890"  # BST 282: Introduction to Computational Biology and Bioinformatics
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+# Check if the groups that the user is in match any of the courses that should
+# have access to this app.
+
+if arrays_have_common_element(userGroups, enabledGroups)
+  cluster="*"
+else
+  cluster="disable_this_app"
+end
+-%>
+---
+# **MUST** set cluster id here that matches cluster configuration file located
+# under /etc/ood/config/clusters.d/*.yml
+# @example Use the Owens cluster at Ohio Supercomputer Center
+#     cluster: "owens"
+cluster: "<%= cluster %>"
+
+title: "RStudio - BST 282"
+
+attributes:
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1
+form:
+  - custom_num_cores
+  - bc_num_hours

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -16,7 +16,7 @@ cd "${HOME}"
 
 spack_environment="apptainer"
 apptainer_image_dir="/shared/apptainerImages"
-rstudio_container="rstudio-base.sif"
+rstudio_container="<%= context.imagefile %>"
 
 # Load the required environment
 setup_env () {


### PR DESCRIPTION
This PR sets up RStudio for BST 282.

### Changes
- Added `build/rstudio-bioconductor.def` which pulls the [bioconductor](https://www.bioconductor.org/help/docker/) docker image (based on the rocker rstudio images).
- Added an `imagefile` attribute to the `form.yml` so the rstudio image can be customized. 
- Added  `local/bst282.yml.erb` sub-app for BST 282 configured to use the bioconductor image.

### Notes

Many of the packages that BST 282 requested must be installed through [Bioconductor](https://www.bioconductor.org/). It's possible to first [install bioconductor](https://www.bioconductor.org/install/) and then install the requested packages, but since bioconductor provides an image that is already setup and since it is based on the same base image we're using (`rocker/rstudio`), we can use that as our base image instead to eliminate that step. This may be useful for other genetics courses as well, and if for some reason it doesn't work, the base image can be substituted.

Using the bioconductor image, the requested packages can be installed with:

```r
BiocManager::install(c("anndata","biobroom","biomaRt","caret","ComplexHeatmap","corrplot","cowplot","DESeq2","dplyr","fgsea","ggfortify","ggplot2","ggrastr","grid","gridExtra","harmony","hgu133plus2.db","kernlab","knitr","limma","maestro","MAGeCKFlute","msigdbr","patchwork","pheatmap","pROC","purrr","RColorBrewer","reticulate","Seurat","stringr","survival","survminer","sva","symphony","tidyr","tidyverse","tximport","viridis"))
```

Once installed, the packages need to be moved to a shared location and course members will need to modify their lib paths accordingly. For details on this step, refer to:

https://github.com/Harvard-ATG/ood-misc-runbooks/blob/main/setups/r.md