### PR TITLE
ECON 2110 Course Setup

### DIFF
--- a/build/rstudio-econ2110.def
+++ b/build/rstudio-econ2110.def
@@ -1,0 +1,64 @@
+Bootstrap: docker
+From: rocker/verse:4.5.1
+
+%post
+R_PACKAGES=(
+    "AER" 
+    "MASS"
+    "binsreg"
+    "boot"
+    "broom"
+    "car"
+    "data.table"
+    "dfadjust"
+    "dplyr"
+    "estimatr"
+    "fixest"
+    "gamlr"
+    "ggplot2"
+    "haven"
+    "ivDiag"
+    "jsonlite"
+    "kableExtra"
+    "lfe"
+    "lib"
+    "lmtest"
+    "lpdensity"
+    "lubridate"
+    "maptpx"
+    "margins"
+    "msm"
+    "np"
+    "nprobust"
+    "oglmx"
+    "randomForest"
+    "remotes"
+    "rdrobust"
+    "rpart"
+    "rpart.plot"
+    "rugarch"
+    "ranger"
+    "sampleSelection"
+    "sandwich"
+    "stargazer"
+    "statar"
+    "textir"
+    "tidyverse"
+    "tm"
+    "zoo"
+)
+
+R_GH_PACKAGES=(
+    "OpportunityInsights/oiplot"
+    "grantmcdermott/lfe2fixest"
+    "manutzn/fredo"
+)
+
+for package in "${R_PACKAGES[@]}"
+do
+Rscript -e "install.packages(\"${package}\")"
+done
+
+for package in "${R_GH_PACKAGES[@]}"
+do
+Rscript -e "devtools::install_github(\"${package}\")

--- a/local/econ2110.yml.erb
+++ b/local/econ2110.yml.erb
@@ -1,0 +1,53 @@
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  "156530"
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+
+---
+cluster: "<%= cluster %>"
+title: "RStudio - ECON 2110"
+
+attributes:
+  imagefile: rstudio-econ2110.sif
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1
+form:
+  - custom_num_cores
+  - bc_num_hours
+  - imagefile


### PR DESCRIPTION
# Overview

Course setup for ECON 2110. This can be tested to validate launch in the prod environment from this branch.

The course requested the following R packages:

```
R libraries for the Jupyter Hub (continues on next page):

AER
MASS
binsreg
boot
broom
car
data.table
dfadjust
dplyr
estimatr
fixest
gamlr
ggplot2
haven
ivDiag
jsonlite
kableExtra
lfe
lib
lmtest
lpdensity
lubridate
maptpx
margins
msm
np
nprobust
oglmx
randomForest
remotes
rdrobust
rpart
rpart.plot
rugarch
ranger
sampleSelection
sandwich
stargazer
statar
textir
tidyverse
tm
zoo
devtools::install_github("OpportunityInsights/oiplot")
remotes::install_github("grantmcdermott/lfe2fixest")
devtools::install_github("manutzn/fredo")
```

# Changes

Adds a config for ECON 2110 with the requested packages installed to the container image defined in the build def.

# Notes

Two packages could not be installed:
- `lib` does not appear to be an R package
- `oglmx` has explicitly been removed from CRAN, per https://cran.r-project.org/web/packages/oglmx/index.html.
